### PR TITLE
Force width to 100% on mobile

### DIFF
--- a/web-app/css/style-overrides.css
+++ b/web-app/css/style-overrides.css
@@ -9,6 +9,10 @@
 	display: inline;
 }
 
+#twitter-widget-0 {
+	width: 100%;
+}
+
 .da-slide p.slider-text {
 	font-size: 24px;
 }


### PR DESCRIPTION
Added styling to force twitter widget width to fill responsive span3 on mobile.
